### PR TITLE
feat: add PR submission trigger to Claude workflow

### DIFF
--- a/.github/workflows/claude_code.yml
+++ b/.github/workflows/claude_code.yml
@@ -9,17 +9,23 @@ on:
     types: [opened, assigned]
   pull_request_review:
     types: [submitted]
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   claude-code-action:
-    # Only respond to @claude mentions from TheIllusionOfLife
+    # Respond to @claude mentions from TheIllusionOfLife OR any pull request submission
     if: |
       (
-        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-        (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
-      ) && github.actor == 'TheIllusionOfLife'
+        (
+          (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+          (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+          (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+          (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
+        ) && github.actor == 'TheIllusionOfLife'
+      ) || (
+        github.event_name == 'pull_request'
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Add pull_request event trigger for opened, synchronize, and reopened events
- Modify if condition to enable Claude assistance on any PR submission from anyone
- Preserve existing @claude mention security restrictions for issue/comment interactions

## Changes Made
- Added `pull_request` event with types: `opened`, `synchronize`, `reopened`
- Updated if condition to include new OR branch for pull_request events
- Updated comment to reflect dual trigger behavior

## Test Plan
- [ ] Verify workflow triggers on new PR creation
- [ ] Verify workflow triggers on PR updates (synchronize)
- [ ] Verify workflow triggers on PR reopening
- [ ] Confirm existing @claude mention behavior still works
- [ ] Confirm security restrictions remain for authorized users only

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow to trigger on more pull request events, ensuring broader and more consistent automation coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->