### PR TITLE
Fix logging configuration during import

### DIFF
--- a/mad_spark_multiagent/coordinator.py
+++ b/mad_spark_multiagent/coordinator.py
@@ -11,10 +11,22 @@ import logging
 import time
 from typing import List, Dict, Any, Optional, TypedDict # Added TypedDict
 
-# --- Logging Configuration ---
-# Note: Logging configuration is now handled by CLI to avoid conflicts
-# If running coordinator.py directly, basic logging will be set up below
-# --- End Logging Configuration ---
+# -------------------------------------------------------------
+# Ensure logging is configured before any module-level log calls
+# -------------------------------------------------------------
+# The coordinator is often imported by the CLI *before* the CLI has a
+# chance to configure logging.  As a safeguard, we set up a very small
+# default configuration **only if** the root logger has no handlers yet.
+# The CLI later re-configures logging with `force=True`, so this fallback
+# will be cleanly replaced and will not interfere with user-level
+# configuration.
+
+if not logging.getLogger().handlers:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(levelname)s - %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
 
 # SECURITY NOTE: Storing API keys directly in environment variables is suitable for
 # local development but not recommended for production.


### PR DESCRIPTION
Add a fallback logging configuration to ensure early module-level log messages are captured and formatted.

Previously, module-level `logging.info()` calls in `coordinator.py` executed during import before the main logging configuration (now handled by the CLI or `if __name__ == "__main__":` block) was set up. This resulted in early log messages being unformatted or lost, which was a regression. This PR introduces a minimal fallback logging configuration that applies only if no handlers are present, ensuring these early messages are properly captured without interfering with later, more comprehensive configurations.