### PR TITLE
fix: resolve React hooks error in BookmarkManager component

### DIFF
--- a/web/frontend/src/components/BookmarkManager.tsx
+++ b/web/frontend/src/components/BookmarkManager.tsx
@@ -55,8 +55,6 @@ const BookmarkManager: React.FC<BookmarkManagerProps> = ({
     };
   }, [isOpen, onClose]);
 
-  if (!isOpen) return null;
-
   // Extract all unique tags
   const allTags = Array.from(new Set(bookmarks.flatMap(b => b.tags)));
 
@@ -73,6 +71,8 @@ const BookmarkManager: React.FC<BookmarkManagerProps> = ({
       return matchesSearch && matchesTag;
     });
   }, [bookmarks, searchQuery, selectedTag]);
+
+  if (!isOpen) return null;
 
   const handleSelectToggle = (bookmarkId: string) => {
     const newSelected = new Set(localSelectedIds);


### PR DESCRIPTION
## Summary
- Fixed React hooks violation where `useMemo` was called conditionally
- Moved the hook before the early return to ensure consistent hook ordering

## Problem
The BookmarkManager component had a React hooks error where `useMemo` was called after a conditional return statement. This violates React's rules of hooks which require hooks to be called in the same order on every render.

## Solution
Moved the `useMemo` hook and the `allTags` calculation before the `if (\!isOpen) return null` statement to ensure hooks are always called in the same order.

## Testing
- Verified the web interface loads without errors
- Tested bookmark manager opens and closes correctly
- Confirmed no React hooks errors in the console