### PR TITLE
🔒 Configure CORS origins via environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,3 +33,8 @@ MADSPARK_CACHE_TTL=86400
 # Default behavior: auto-detects based on API key presence
 # MADSPARK_MODE=api
 MAX_CONCURRENT_AGENTS=10
+
+# Security Configuration
+# Comma-separated list of allowed origins for CORS.
+# Defaults to http://localhost:3000,http://127.0.0.1:3000 if not set.
+# MADSPARK_CORS_ORIGINS=http://localhost:3000,http://127.0.0.1:3000,https://my-production-domain.com

--- a/tests/test_cors_security.py
+++ b/tests/test_cors_security.py
@@ -1,0 +1,76 @@
+import os
+import importlib
+from unittest.mock import patch
+import pytest
+from fastapi.middleware.cors import CORSMiddleware
+
+# We need to import the module to be able to reload it
+# Assuming the python path is set up correctly to include the root of the repo
+import web.backend.main
+
+def get_cors_middleware(app):
+    """Helper to find CORSMiddleware in the app."""
+    for middleware in app.user_middleware:
+        if middleware.cls == CORSMiddleware:
+            return middleware
+    return None
+
+def test_default_cors_configuration():
+    """Verify that the default CORS configuration is correct."""
+    # Ensure MADSPARK_CORS_ORIGINS is not set
+    with patch.dict(os.environ, {}, clear=True):
+        # We need to reload because the app is created at module level
+        importlib.reload(web.backend.main)
+        app = web.backend.main.app
+
+        cors_middleware = get_cors_middleware(app)
+        assert cors_middleware is not None, "CORSMiddleware not found"
+
+        # In newer Starlette/FastAPI versions, Middleware stores options in kwargs or options
+        # Based on previous debug output, it's kwargs
+        options = getattr(cors_middleware, "options", getattr(cors_middleware, "kwargs", {}))
+
+        origins = options.get("allow_origins")
+        assert origins is not None
+        assert "http://localhost:3000" in origins
+        assert "http://127.0.0.1:3000" in origins
+        assert len(origins) == 2
+
+def test_custom_cors_configuration():
+    """Verify that MADSPARK_CORS_ORIGINS env var updates CORS configuration."""
+    custom_origins = "https://example.com,https://api.example.com"
+
+    with patch.dict(os.environ, {"MADSPARK_CORS_ORIGINS": custom_origins}):
+        importlib.reload(web.backend.main)
+        app = web.backend.main.app
+
+        cors_middleware = get_cors_middleware(app)
+        assert cors_middleware is not None, "CORSMiddleware not found"
+
+        options = getattr(cors_middleware, "options", getattr(cors_middleware, "kwargs", {}))
+        origins = options.get("allow_origins")
+
+        assert origins is not None
+        assert "https://example.com" in origins
+        assert "https://api.example.com" in origins
+        assert len(origins) == 2
+        assert "http://localhost:3000" not in origins
+
+def test_custom_cors_configuration_with_whitespace():
+    """Verify that whitespace is stripped from MADSPARK_CORS_ORIGINS."""
+    custom_origins = " https://example.com ,  https://api.example.com "
+
+    with patch.dict(os.environ, {"MADSPARK_CORS_ORIGINS": custom_origins}):
+        importlib.reload(web.backend.main)
+        app = web.backend.main.app
+
+        cors_middleware = get_cors_middleware(app)
+        assert cors_middleware is not None, "CORSMiddleware not found"
+
+        options = getattr(cors_middleware, "options", getattr(cors_middleware, "kwargs", {}))
+        origins = options.get("allow_origins")
+
+        assert origins is not None
+        assert "https://example.com" in origins
+        assert "https://api.example.com" in origins
+        assert len(origins) == 2

--- a/tests/test_cors_security.py
+++ b/tests/test_cors_security.py
@@ -1,5 +1,6 @@
 import os
 import importlib
+import pytest
 from unittest.mock import patch
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -17,7 +18,8 @@ def get_cors_middleware(app):
 def test_default_cors_configuration():
     """Verify that the default CORS configuration is correct."""
     # Ensure MADSPARK_CORS_ORIGINS is not set
-    with patch.dict(os.environ, {}, clear=True):
+    with patch.dict(os.environ, {"MADSPARK_MODE": "mock"}):
+        os.environ.pop("MADSPARK_CORS_ORIGINS", None)
         # We need to reload because the app is created at module level
         importlib.reload(web.backend.main)
         app = web.backend.main.app
@@ -39,7 +41,10 @@ def test_custom_cors_configuration():
     """Verify that MADSPARK_CORS_ORIGINS env var updates CORS configuration."""
     custom_origins = "https://example.com,https://api.example.com"
 
-    with patch.dict(os.environ, {"MADSPARK_CORS_ORIGINS": custom_origins}):
+    with patch.dict(
+        os.environ,
+        {"MADSPARK_CORS_ORIGINS": custom_origins, "MADSPARK_MODE": "mock"},
+    ):
         importlib.reload(web.backend.main)
         app = web.backend.main.app
 
@@ -59,7 +64,10 @@ def test_custom_cors_configuration_with_whitespace():
     """Verify that whitespace is stripped from MADSPARK_CORS_ORIGINS."""
     custom_origins = " https://example.com ,  https://api.example.com "
 
-    with patch.dict(os.environ, {"MADSPARK_CORS_ORIGINS": custom_origins}):
+    with patch.dict(
+        os.environ,
+        {"MADSPARK_CORS_ORIGINS": custom_origins, "MADSPARK_MODE": "mock"},
+    ):
         importlib.reload(web.backend.main)
         app = web.backend.main.app
 
@@ -73,3 +81,30 @@ def test_custom_cors_configuration_with_whitespace():
         assert "https://example.com" in origins
         assert "https://api.example.com" in origins
         assert len(origins) == 2
+
+
+def test_empty_custom_origins_falls_back_to_defaults():
+    """Whitespace-only env var should fall back to secure defaults."""
+    with patch.dict(
+        os.environ,
+        {"MADSPARK_CORS_ORIGINS": " ,  , ", "MADSPARK_MODE": "mock"},
+    ):
+        importlib.reload(web.backend.main)
+        app = web.backend.main.app
+
+        cors_middleware = get_cors_middleware(app)
+        assert cors_middleware is not None, "CORSMiddleware not found"
+
+        options = getattr(cors_middleware, "options", getattr(cors_middleware, "kwargs", {}))
+        origins = options.get("allow_origins")
+        assert origins == ["http://localhost:3000", "http://127.0.0.1:3000"]
+
+
+def test_wildcard_origin_with_credentials_is_rejected():
+    """Reject wildcard CORS origin when credentials are enabled."""
+    with patch.dict(
+        os.environ,
+        {"MADSPARK_CORS_ORIGINS": "*", "MADSPARK_MODE": "mock"},
+    ):
+        with pytest.raises(ValueError, match="MADSPARK_CORS_ORIGINS='\\*'"):
+            importlib.reload(web.backend.main)

--- a/tests/test_cors_security.py
+++ b/tests/test_cors_security.py
@@ -1,7 +1,6 @@
 import os
 import importlib
 from unittest.mock import patch
-import pytest
 from fastapi.middleware.cors import CORSMiddleware
 
 # We need to import the module to be able to reload it

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -602,9 +602,16 @@ else:
     logging.info("Rate limiting disabled in mock/test mode (10000/minute)")
 
 # Configure CORS
+cors_origins_str = os.getenv("MADSPARK_CORS_ORIGINS", "")
+if cors_origins_str:
+    cors_origins = [origin.strip() for origin in cors_origins_str.split(",") if origin.strip()]
+else:
+    # Default to React dev server
+    cors_origins = ["http://localhost:3000", "http://127.0.0.1:3000"]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:3000", "http://127.0.0.1:3000"],  # React dev server
+    allow_origins=cors_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -602,12 +602,17 @@ else:
     logging.info("Rate limiting disabled in mock/test mode (10000/minute)")
 
 # Configure CORS
+DEFAULT_CORS_ORIGINS = ["http://localhost:3000", "http://127.0.0.1:3000"]
 cors_origins_str = os.getenv("MADSPARK_CORS_ORIGINS", "")
-if cors_origins_str:
-    cors_origins = [origin.strip() for origin in cors_origins_str.split(",") if origin.strip()]
-else:
-    # Default to React dev server
-    cors_origins = ["http://localhost:3000", "http://127.0.0.1:3000"]
+cors_origins = [origin.strip() for origin in cors_origins_str.split(",") if origin.strip()]
+if not cors_origins:
+    cors_origins = DEFAULT_CORS_ORIGINS.copy()
+
+if cors_origins == ["*"]:
+    raise ValueError(
+        "Invalid CORS configuration: MADSPARK_CORS_ORIGINS='*' is not allowed "
+        "when allow_credentials=True. Use explicit origins instead."
+    )
 
 app.add_middleware(
     CORSMiddleware,


### PR DESCRIPTION
This PR addresses a security vulnerability where CORS allowed origins were hardcoded. It introduces the `MADSPARK_CORS_ORIGINS` environment variable to configure allowed origins, providing a secure and flexible way to manage CORS policies in different environments. The default behavior remains unchanged for development convenience. A new test file `tests/test_cors_security.py` verifies the fix.

---
*PR created automatically by Jules for task [13617725141466488145](https://jules.google.com/task/13617725141466488145) started by @TheIllusionOfLife*