### PR TITLE
fix(security): prevent sensitive info disclosure in error responses

### DIFF
--- a/tests/test_security_error_handling.py
+++ b/tests/test_security_error_handling.py
@@ -1,142 +1,146 @@
-
-import pytest
-from unittest.mock import patch, MagicMock
 import os
 import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
 
 # Ensure we can import web.backend.main
 sys.path.append(os.path.join(os.getcwd(), "web", "backend"))
 sys.path.append(os.path.join(os.getcwd(), "src"))
 
-from web.backend.main import app, initialize_components_for_testing
-from fastapi.testclient import TestClient
-
-# Initialize components (this might log errors about missing files, ignore them)
-initialize_components_for_testing()
-
-client = TestClient(app)
+from web.backend.main import app, error_tracker, initialize_components_for_testing
 
 SENSITIVE_INFO = "SENSITIVE_DB_PASSWORD_12345"
 
+
+@pytest.fixture
+def test_client():
+    initialize_components_for_testing()
+    with patch.dict(
+        os.environ,
+        {
+            "MADSPARK_MODE": "mock",
+            "ENVIRONMENT": "test",
+            "GOOGLE_API_KEY": "test-key",
+        },
+        clear=False,
+    ):
+        yield TestClient(app)
+
+
 class TestSecurityErrorHandling:
-
     @patch("web.backend.main.AsyncCoordinator")
-    def test_generate_ideas_error_leak(self, MockCoordinator):
+    def test_generate_ideas_error_leak(self, MockCoordinator, test_client):
         """Test that generate_ideas endpoint does not leak sensitive exception details."""
-        # Force production mode to ensure we don't hit the mock path
-        # We need to set these env vars so parse_idea_request doesn't trigger mock mode
-        env_vars = {
-            "MADSPARK_MODE": "production",
-            "ENVIRONMENT": "production",
-            "GOOGLE_API_KEY": "valid-key-for-test"
-        }
+        mock_instance = MockCoordinator.return_value
+        mock_instance.run_workflow = AsyncMock(
+            side_effect=ValueError(f"Connection failed: {SENSITIVE_INFO}")
+        )
 
-        with patch.dict(os.environ, env_vars):
-            mock_instance = MockCoordinator.return_value
-
-            async def side_effect(*args, **kwargs):
-                raise ValueError(f"Connection failed: {SENSITIVE_INFO}")
-
-            mock_instance.run_workflow.side_effect = side_effect
-
-            response = client.post(
+        with patch("web.backend.main._is_mock_mode", return_value=False):
+            response = test_client.post(
                 "/api/generate-ideas",
                 json={
                     "topic": "test",
                     "context": "test context",
-                    "num_top_candidates": 1
-                }
+                    "num_top_candidates": 1,
+                },
             )
 
-            assert response.status_code == 500
-            data = response.json()
-
-            detail = data.get("detail", {})
-            if isinstance(detail, dict):
-                error_msg = detail.get("error", "")
-                assert SENSITIVE_INFO not in error_msg
-                assert error_msg == "An internal error occurred during idea generation."
-                assert detail.get("type") == "InternalServerError"
-            else:
-                pytest.fail(f"Unexpected detail format: {detail}")
+        assert response.status_code == 500
+        detail = response.json().get("detail", {})
+        assert isinstance(detail, dict)
+        assert detail.get("error") == "An internal error occurred during idea generation."
+        assert detail.get("type") == "InternalServerError"
+        assert SENSITIVE_INFO not in str(detail)
 
     @patch("web.backend.main.AsyncCoordinator")
-    def test_generate_ideas_async_error_leak(self, MockCoordinator):
+    def test_generate_ideas_async_error_leak(self, MockCoordinator, test_client):
         """Test that generate_ideas_async endpoint does not leak sensitive exception details."""
-        env_vars = {
-            "MADSPARK_MODE": "production",
-            "ENVIRONMENT": "production",
-            "GOOGLE_API_KEY": "valid-key-for-test"
-        }
+        mock_instance = MockCoordinator.return_value
+        mock_instance.run_workflow = AsyncMock(
+            side_effect=ValueError(f"Connection failed: {SENSITIVE_INFO}")
+        )
 
-        with patch.dict(os.environ, env_vars):
-            mock_instance = MockCoordinator.return_value
-
-            async def side_effect(*args, **kwargs):
-                raise ValueError(f"Connection failed: {SENSITIVE_INFO}")
-
-            mock_instance.run_workflow.side_effect = side_effect
-
-            response = client.post(
+        with patch("web.backend.main._is_mock_mode", return_value=False):
+            response = test_client.post(
                 "/api/generate-ideas-async",
                 json={
                     "topic": "test",
                     "context": "test context",
-                    "num_top_candidates": 1
-                }
+                    "num_top_candidates": 1,
+                },
             )
 
-            assert response.status_code == 500
-            data = response.json()
-
-            detail = data.get("detail", "")
-            assert SENSITIVE_INFO not in str(detail)
-            assert detail == "An internal error occurred."
+        assert response.status_code == 500
+        detail = response.json().get("detail", "")
+        assert detail == "An internal error occurred."
+        assert SENSITIVE_INFO not in detail
 
     @patch("web.backend.main.BookmarkManager")
-    def test_check_bookmark_duplicates_error_leak(self, MockBookmarkManagerClass):
+    def test_check_bookmark_duplicates_error_leak(
+        self, MockBookmarkManagerClass, test_client
+    ):
         """Test that check_bookmark_duplicates endpoint does not leak sensitive exception details."""
-
-        # Configure the mock instance returned by the class constructor
         mock_instance = MockBookmarkManagerClass.return_value
-        # Configure the method to raise exception
-        mock_instance.check_for_duplicates.side_effect = ValueError(f"DB Error: {SENSITIVE_INFO}")
+        mock_instance.check_for_duplicates.side_effect = ValueError(
+            f"DB Error: {SENSITIVE_INFO}"
+        )
 
-        # Ensure we are using the patched class.
-        # Note: If duplicate_request.similarity_threshold is set (default 0.8),
-        # main.py instantiates BookmarkManager().
-
-        response = client.post(
+        response = test_client.post(
             "/api/bookmarks/check-duplicates",
-            json={
-                "idea": "test idea long enough",
-                "topic": "test topic"
-            }
+            json={"idea": "test idea long enough", "topic": "test topic"},
         )
 
         assert response.status_code == 500
-        data = response.json()
-
-        detail = data.get("detail", "")
-        assert SENSITIVE_INFO not in str(detail)
+        detail = response.json().get("detail", "")
         assert detail == "Internal server error"
+        assert SENSITIVE_INFO not in detail
 
     @patch("web.backend.main.TemperatureManager")
-    def test_get_temperature_presets_error_leak(self, MockTempManager):
+    def test_get_temperature_presets_error_leak(self, MockTempManager, test_client):
         """Test that get_temperature_presets endpoint does not leak sensitive exception details."""
-        # Mocking items on the class attribute PRESETS
         mock_presets = MagicMock()
         mock_presets.items.side_effect = ValueError(f"Config Error: {SENSITIVE_INFO}")
         MockTempManager.PRESETS = mock_presets
 
-        response = client.get("/api/temperature-presets")
+        response = test_client.get("/api/temperature-presets")
 
         assert response.status_code == 500
-        data = response.json()
-
-        detail = data.get("detail", "")
-        assert SENSITIVE_INFO not in str(detail)
+        detail = response.json().get("detail", "")
         assert detail == "Internal server error"
+        assert SENSITIVE_INFO not in detail
 
-if __name__ == "__main__":
-    pytest.main([__file__, "-v"])
+    @patch("web.backend.main.bookmark_system")
+    def test_delete_bookmark_not_found_stays_404(self, mock_bookmark_system, test_client):
+        """Test that missing bookmarks return 404 rather than being converted to 500."""
+        mock_bookmark_system.remove_bookmark.return_value = False
+
+        response = test_client.delete("/api/bookmarks/non-existent-id")
+
+        assert response.status_code == 404
+        detail = response.json().get("detail", "")
+        assert "not found" in detail.lower()
+
+    def test_error_stats_redacts_sensitive_messages(self, test_client):
+        """Test that /api/system/errors redacts exception message content."""
+        original_errors = list(error_tracker.errors)
+        try:
+            error_tracker.errors = []
+            error_tracker.track_error(
+                "test_security_error",
+                f"Connection string leaked: {SENSITIVE_INFO}",
+                {"source": "test"},
+            )
+
+            response = test_client.get("/api/system/errors")
+
+            assert response.status_code == 200
+            payload = response.json()
+            recent_errors = payload["error_stats"]["recent_errors"]
+            assert recent_errors
+            assert recent_errors[0]["message"] == "[REDACTED]"
+            assert SENSITIVE_INFO not in str(recent_errors[0])
+        finally:
+            error_tracker.errors = original_errors

--- a/tests/test_security_error_handling.py
+++ b/tests/test_security_error_handling.py
@@ -1,0 +1,128 @@
+
+import pytest
+from unittest.mock import patch, MagicMock
+import os
+import sys
+
+# Ensure we can import web.backend.main
+sys.path.append(os.path.join(os.getcwd(), "web", "backend"))
+sys.path.append(os.path.join(os.getcwd(), "src"))
+
+# Set environment variables BEFORE importing app to avoid mock mode
+os.environ["MADSPARK_MODE"] = "production"
+os.environ["GOOGLE_API_KEY"] = "valid-key-for-test"
+os.environ["ENVIRONMENT"] = "production"
+
+from web.backend.main import app, initialize_components_for_testing
+from fastapi.testclient import TestClient
+
+# Initialize components
+initialize_components_for_testing()
+
+client = TestClient(app)
+
+SENSITIVE_INFO = "SENSITIVE_DB_PASSWORD_12345"
+
+class TestSecurityErrorHandling:
+
+    @patch("web.backend.main.AsyncCoordinator")
+    def test_generate_ideas_error_leak(self, MockCoordinator):
+        """Test that generate_ideas endpoint does not leak sensitive exception details."""
+        mock_instance = MockCoordinator.return_value
+
+        async def side_effect(*args, **kwargs):
+            raise ValueError(f"Connection failed: {SENSITIVE_INFO}")
+
+        mock_instance.run_workflow.side_effect = side_effect
+
+        response = client.post(
+            "/api/generate-ideas",
+            json={
+                "topic": "test",
+                "context": "test context",
+                "num_top_candidates": 1
+            }
+        )
+
+        assert response.status_code == 500
+        data = response.json()
+
+        detail = data.get("detail", {})
+        if isinstance(detail, dict):
+            error_msg = detail.get("error", "")
+            assert SENSITIVE_INFO not in error_msg
+            assert error_msg == "An internal error occurred during idea generation."
+            assert detail.get("type") == "InternalServerError"
+
+    @patch("web.backend.main.AsyncCoordinator")
+    def test_generate_ideas_async_error_leak(self, MockCoordinator):
+        """Test that generate_ideas_async endpoint does not leak sensitive exception details."""
+        mock_instance = MockCoordinator.return_value
+
+        async def side_effect(*args, **kwargs):
+            raise ValueError(f"Connection failed: {SENSITIVE_INFO}")
+
+        mock_instance.run_workflow.side_effect = side_effect
+
+        response = client.post(
+            "/api/generate-ideas-async",
+            json={
+                "topic": "test",
+                "context": "test context",
+                "num_top_candidates": 1
+            }
+        )
+
+        assert response.status_code == 500
+        data = response.json()
+
+        detail = data.get("detail", "")
+        assert SENSITIVE_INFO not in str(detail)
+        assert detail == "An internal error occurred."
+
+    @patch("web.backend.main.BookmarkManager")
+    @patch("web.backend.main.bookmark_system") # Patch the global variable too just in case
+    def test_check_bookmark_duplicates_error_leak(self, mock_global_bm, MockBookmarkManagerClass):
+        """Test that check_bookmark_duplicates endpoint does not leak sensitive exception details."""
+
+        # When BookmarkManager(...) is called, return a mock that raises exception on check_for_duplicates
+        mock_instance = MockBookmarkManagerClass.return_value
+        mock_instance.check_for_duplicates.side_effect = ValueError(f"DB Error: {SENSITIVE_INFO}")
+
+        # Also configure the global one just in case code path takes 'else'
+        mock_global_bm.check_for_duplicates.side_effect = ValueError(f"DB Error: {SENSITIVE_INFO}")
+
+        response = client.post(
+            "/api/bookmarks/check-duplicates",
+            json={
+                "idea": "test idea long enough",
+                "topic": "test topic",
+                # similarity_threshold is default 0.8, so it will likely instantiate new BookmarkManager
+            }
+        )
+
+        assert response.status_code == 500
+        data = response.json()
+
+        detail = data.get("detail", "")
+        assert SENSITIVE_INFO not in str(detail)
+        assert detail == "Internal server error"
+
+    @patch("web.backend.main.TemperatureManager")
+    def test_get_temperature_presets_error_leak(self, MockTempManager):
+        """Test that get_temperature_presets endpoint does not leak sensitive exception details."""
+        mock_presets = MagicMock()
+        mock_presets.items.side_effect = ValueError(f"Config Error: {SENSITIVE_INFO}")
+        MockTempManager.PRESETS = mock_presets
+
+        response = client.get("/api/temperature-presets")
+
+        assert response.status_code == 500
+        data = response.json()
+
+        detail = data.get("detail", "")
+        assert SENSITIVE_INFO not in str(detail)
+        assert detail == "Internal server error"
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_web_api_fixes.py
+++ b/tests/test_web_api_fixes.py
@@ -110,10 +110,14 @@ class TestWebAPIFixes:
     @pytest.mark.integration
     def test_bookmark_field_validation(self, client):
         """Test bookmark creation with proper field validation."""
+        # Use unique idea to avoid duplicate detection issues
+        import uuid
+        unique_id = str(uuid.uuid4())
+
         bookmark_data = {
             "topic": "test topic",
             "context": "test context",
-            "idea": "test idea that is long enough to meet validation",
+            "idea": f"test idea that is long enough to meet validation {unique_id}",
             "improved_idea": "test improved idea that also meets length requirements",
             "initial_critique": "test critique with sufficient length",
             "advocacy": "test advocacy with sufficient length",
@@ -122,7 +126,8 @@ class TestWebAPIFixes:
             "improved_score": 8.5
         }
         
-        response = client.post("/api/bookmarks", json=bookmark_data)
+        # Disable duplicate check to ensure creation
+        response = client.post("/api/bookmarks?check_duplicates=false", json=bookmark_data)
         assert response.status_code in [200, 201]
         
         created = response.json()

--- a/tests/test_web_api_fixes.py
+++ b/tests/test_web_api_fixes.py
@@ -1,6 +1,7 @@
 """Tests for Web API fixes and improvements."""
 
 import pytest
+import uuid
 from datetime import datetime
 from unittest.mock import patch
 
@@ -111,7 +112,6 @@ class TestWebAPIFixes:
     def test_bookmark_field_validation(self, client):
         """Test bookmark creation with proper field validation."""
         # Use unique idea to avoid duplicate detection issues
-        import uuid
         unique_id = str(uuid.uuid4())
 
         bookmark_data = {

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -1652,8 +1652,6 @@ async def generate_ideas(
         error_detail = {
             "error": "An internal error occurred during idea generation.",
             "type": "InternalServerError",
-            "processing_time": processing_time,
-            "context": "idea_generation"
         }
         raise HTTPException(status_code=500, detail=error_detail)
 

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -1179,7 +1179,7 @@ async def get_temperature_presets():
         }
     except Exception as e:
         logger.error(f"Failed to get temperature presets: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail="Internal server error")
 
 
 # LLM Router endpoints
@@ -1238,7 +1238,7 @@ async def get_llm_metrics():
         }
     except Exception as e:
         logger.error(f"Failed to get LLM metrics: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail="Internal server error")
 
 
 @app.post(
@@ -1263,7 +1263,7 @@ async def clear_llm_cache():
         }
     except Exception as e:
         logger.error(f"Failed to clear LLM cache: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail="Internal server error")
 
 
 @app.get(
@@ -1638,12 +1638,13 @@ async def generate_ideas(
         }
         
         error_tracker.track_error('idea_generation', str(e), error_context)
-        await ws_manager.send_progress_update(f"Error: {str(e)}", 0.0)
+        await ws_manager.send_progress_update("Error: An internal error occurred during idea generation.", 0.0)
         
-        # Provide more detailed error information
+        # Provide more detailed error information (sanitized for user)
+        # SECURE: Do not leak exception details to user
         error_detail = {
-            "error": str(e),
-            "type": type(e).__name__,
+            "error": "An internal error occurred during idea generation.",
+            "type": "InternalServerError",
             "processing_time": processing_time,
             "context": "idea_generation"
         }
@@ -1758,8 +1759,9 @@ async def generate_ideas_async(request: Request, idea_request: IdeaGenerationReq
 
     except Exception as e:
         logger.error(f"Async idea generation failed: {e}")
-        await ws_manager.send_progress_update(f"Error: {str(e)}", 0.0)
-        raise HTTPException(status_code=500, detail=str(e))
+        await ws_manager.send_progress_update("Error: An internal error occurred.", 0.0)
+        # SECURE: Generic error for user
+        raise HTTPException(status_code=500, detail="An internal error occurred.")
     finally:
         # Router cleanup not needed - request-scoped router will be garbage collected
         pass
@@ -1846,7 +1848,7 @@ async def check_bookmark_duplicates(request: Request, duplicate_request: Duplica
             'error_type': type(e).__name__
         }
         error_tracker.track_error('duplicate_check', str(e), error_context)
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail="Internal server error")
 
 
 @app.get("/api/bookmarks/similar")
@@ -1896,7 +1898,7 @@ async def find_similar_bookmarks(
             'error_type': type(e).__name__
         }
         error_tracker.track_error('similar_search', str(e), error_context)
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail="Internal server error")
 
 
 @app.get("/api/bookmarks")
@@ -1933,7 +1935,7 @@ async def get_bookmarks(request: Request, tags: Optional[str] = None):
         }
     except Exception as e:
         logger.error(f"Failed to get bookmarks: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail="Internal server error")
 
 
 @app.post("/api/bookmarks", response_model=EnhancedBookmarkResponse)
@@ -2025,7 +2027,7 @@ async def create_bookmark(
         }
         
         error_tracker.track_error('bookmark_creation', str(e), error_context)
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail="Internal server error")
 
 
 @app.delete("/api/bookmarks/{bookmark_id}")
@@ -2050,7 +2052,7 @@ async def delete_bookmark(request: Request, bookmark_id: str):
         }
         
         error_tracker.track_error('bookmark_deletion', str(e), error_context)
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail="Internal server error")
 
 
 @app.get("/api/cache/stats")
@@ -2068,7 +2070,7 @@ async def get_cache_stats():
         
     except Exception as e:
         logger.error(f"Failed to get cache stats: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail="Internal server error")
 
 
 @app.post("/api/cache/invalidate")
@@ -2096,7 +2098,7 @@ async def invalidate_cache(pattern: Optional[str] = None):
             
     except Exception as e:
         error_tracker.track_error('cache_invalidation', str(e), {'pattern': pattern})
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail="Internal server error")
 
 
 @app.get("/api/system/errors")
@@ -2115,7 +2117,7 @@ async def get_error_stats():
         }
     except Exception as e:
         logger.error(f"Failed to get error stats: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail="Internal server error")
 
 
 @app.get("/api/system/health")
@@ -2152,7 +2154,7 @@ async def detailed_health_check():
             status_code=503,
             content={
                 "status": "unhealthy", 
-                "error": str(e),
+                "error": "Internal server error",
                 "timestamp": datetime.now().isoformat()
             }
         )


### PR DESCRIPTION
This PR fixes a security vulnerability where sensitive information (e.g., database connection strings, internal paths) could be disclosed to users via API error messages.

Changes:
- In `web/backend/main.py`, replaced `detail=str(e)` with generic messages like "Internal server error" or "An internal error occurred" for 500 status codes.
- Updated `generate_ideas` and `generate_ideas_async` endpoints to sanitized error details.
- Updated WebSocket progress updates to send generic error messages.
- Added a new test file `tests/test_security_error_handling.py` that uses `unittest.mock` to simulate internal errors containing sensitive data and asserts that the API response does not contain this data.
- Verified existing tests pass.

This ensures that while developers can still see detailed errors in logs, attackers cannot glean internal system details from API responses.

---
*PR created automatically by Jules for task [7911245326508069615](https://jules.google.com/task/7911245326508069615) started by @TheIllusionOfLife*